### PR TITLE
fix(portfolio-link): fixes invalid portfolio link in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hi ![](https://user-images.githubusercontent.com/18350557/176309783-0785949b-912
 Software Engineer and Designer
 ------------------------------
 
-* 🖥️  See my portfolio at [My Portfolio](http://https://brandporto.netlify.app/)
+* 🖥️  See my portfolio at [My Portfolio](https://brandporto.netlify.app/)
 * ✉️  You can contact me at [ismaelmurekezi1@gmail.com](mailto:ismaelmurekezi1@gmail.com)
 * 🚀  I'm currently working on [DevPulse](http://atlp-devpulse-fn.vercel.app/)
 * 🧠  I'm learning Django


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change corrects the URL for the portfolio link.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7): Fixed the URL for the portfolio link by removing an extra "http://".